### PR TITLE
Add WMS support for EPSG:3857

### DIFF
--- a/packages/gl-core/src/source/tile.ts
+++ b/packages/gl-core/src/source/tile.ts
@@ -7,8 +7,9 @@ import { containTile, resolveURL } from '../utils/common';
 import type TileID from '../tile/TileID';
 import type Tile from '../tile/Tile';
 import type Layer from '../renderer';
+import { DEFAULT_URL_DATA } from './urlData';
 
-const URL_PATTERN = /\{ *([\w_]+) *\}/g;
+const URL_PATTERN = /\{ *([\w_-]+) *\}/g;
 
 function formatUrl(url: string, data: any) {
   return url.replace(URL_PATTERN, (str, key) => {
@@ -190,6 +191,8 @@ export default class TileSource extends EventEmitter {
       y,
       z,
       s: domain,
+      ...DEFAULT_URL_DATA,             // Default url data. Ex : {bbox-epsg-3857} for WMS EPSG:3857 bbox (same name as in the MapLibre library)
+      ...(this.options?.urlData || {}) // Additional url data added using the TileSource constructor options
     };
 
     if (Array.isArray(this.url)) {

--- a/packages/gl-core/src/source/urlData.ts
+++ b/packages/gl-core/src/source/urlData.ts
@@ -1,0 +1,27 @@
+/**
+ * Generate WMS GepMap BBOX parameter
+ * @param data - tile url data
+ * @returns 
+ */
+export function bboxEpsg3857({ x, y, z } : {x:number, y:number, z:number, [key: string]: any}) {
+  const gridSize = Math.pow(2, z); // Total world grid at zoom level
+  const mercatorSize = 2 * 20037508.34; // Half the world's circumference in EPSG:3857 in meters
+  const cellSize = mercatorSize / gridSize; // TMS cell size in meters
+
+  // Convert tile coordinates to EPSG:3857
+  const minX = (x / gridSize) * mercatorSize - mercatorSize / 2;
+  const maxX = minX + cellSize;
+  const maxY = mercatorSize / 2 - (y / gridSize) * mercatorSize;
+  const minY = maxY - cellSize;
+
+  return [
+    minX.toFixed(2),
+    minY.toFixed(2),
+    maxX.toFixed(2),
+    maxY.toFixed(2),
+  ].join(",");
+}
+
+export const DEFAULT_URL_DATA = {
+    'bbox-epsg-3857': bboxEpsg3857
+}

--- a/packages/gl-core/src/source/urlData.ts
+++ b/packages/gl-core/src/source/urlData.ts
@@ -1,9 +1,9 @@
 /**
  * Generate WMS GepMap BBOX parameter
  * @param data - tile url data
- * @returns 
+ * @returns
  */
-export function bboxEpsg3857({ x, y, z } : {x:number, y:number, z:number, [key: string]: any}) {
+export function bboxEpsg3857({ x, y, z }: { x: number; y: number; z: number; [key: string]: any }) {
   const gridSize = Math.pow(2, z); // Total world grid at zoom level
   const mercatorSize = 2 * 20037508.34; // Half the world's circumference in EPSG:3857 in meters
   const cellSize = mercatorSize / gridSize; // TMS cell size in meters
@@ -14,14 +14,12 @@ export function bboxEpsg3857({ x, y, z } : {x:number, y:number, z:number, [key: 
   const maxY = mercatorSize / 2 - (y / gridSize) * mercatorSize;
   const minY = maxY - cellSize;
 
-  return [
-    minX.toFixed(2),
-    minY.toFixed(2),
-    maxX.toFixed(2),
-    maxY.toFixed(2),
-  ].join(",");
+  return [minX.toFixed(2), minY.toFixed(2), maxX.toFixed(2), maxY.toFixed(2)].join(',');
 }
 
+/**
+ * Url Data available for all requests
+ */
 export const DEFAULT_URL_DATA = {
-    'bbox-epsg-3857': bboxEpsg3857
-}
+  'bbox-epsg-3857': bboxEpsg3857,
+};

--- a/packages/gl-core/src/type.ts
+++ b/packages/gl-core/src/type.ts
@@ -136,6 +136,7 @@ export type Bounds = [number, number, number, number];
 
 export interface TileSourceOptions {
   url: string | [string, string];
+  urlData?: Record<string, any>;
   type?: LayerSourceType.tile;
   minZoom?: number;
   maxZoom?: number;

--- a/packages/maplibre-gl/README.md
+++ b/packages/maplibre-gl/README.md
@@ -198,7 +198,7 @@ const tileSource = new maplibreWind.TileSource('wind', {
   dataRange: [
     [-21.381948471069336,23.992563247680664],
     [-20.644954681396484,21.251964569091797],
-  ]
+  ],
   wrapX: true,
   url: 'http://myWmsServer/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&TRANSPARENT=true&LAYERS=myWindLayer&STYLES=default&WIDTH=256&HEIGHT=256&FORMAT=image/png&BBOX={bbox-epsg-3857}&CRS=EPSG:3857',
 });
@@ -235,11 +235,6 @@ const layer = new maplibreWind.Layer('wind', tileSource, {
   renderFrom: maplibreWind.RenderFrom.rg,
   displayRange: [0, 104],
   renderType: maplibreWind.RenderType.particles,
-  // mask: {
-  //   data: clip,
-  //   // type: maplibreWind.MaskType.outside,
-  //   type: maplibreWind.MaskType.inside, // 默认是 inside，即只显示范围内的
-  // }
 });
 
 map.addLayer(layer);

--- a/packages/maplibre-gl/README.md
+++ b/packages/maplibre-gl/README.md
@@ -186,6 +186,65 @@ const layer = new maplibreWind.Layer('wind', tileSource, {
 map.addLayer(layer);
 ```
 
+### Tile WMS
+
+```js
+const tileSource = new maplibreWind.TileSource('wind', {
+  tileSize: 256,
+  minZoom: 0,
+  maxZoom: 4,
+  roundZoom: true,
+  decodeType: maplibreWind.DecodeType.image,
+  dataRange: [
+    [-21.381948471069336,23.992563247680664],
+    [-20.644954681396484,21.251964569091797],
+  ]
+  wrapX: true,
+  url: 'http://myWmsServer/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&TRANSPARENT=true&LAYERS=myWindLayer&STYLES=default&WIDTH=256&HEIGHT=256&FORMAT=image/png&BBOX={bbox-epsg-3857}&CRS=EPSG:3857',
+});
+
+const layer = new maplibreWind.Layer('wind', tileSource, {
+  styleSpec: {
+    'fill-color': [
+      'interpolate',
+      ['step', 1],
+      ['get', 'value'],
+      0, '#fff',
+      104, '#fff',
+    ],
+    'opacity': [
+      'interpolate',
+      ['exponential', 0.5],
+      ['zoom'],
+      1,
+      1,
+      2,
+      1
+    ],
+    numParticles: [
+      'interpolate',
+      ['exponential', 0.5],
+      ['zoom'],
+      0, // zoom
+      65535 / 8, // numParticles
+      8, // zoom
+      65535 / 16 // numParticles
+    ],
+    ...particlesConfig,
+  },
+  renderFrom: maplibreWind.RenderFrom.rg,
+  displayRange: [0, 104],
+  renderType: maplibreWind.RenderType.particles,
+  // mask: {
+  //   data: clip,
+  //   // type: maplibreWind.MaskType.outside,
+  //   type: maplibreWind.MaskType.inside, // 默认是 inside，即只显示范围内的
+  // }
+});
+
+map.addLayer(layer);
+```
+
 ## 数据源
 
 数据源支持 3 类


### PR DESCRIPTION
First thank you for your library !

I need to access to images from Maplibre using WMS protocole. I modified gl-core module using the same syntax as in Maplibre WMS layer. I use the {bbox-epsg-3857} pattern replace by the WMS bbox at runtime. Request example :


`http://myWmsServer/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&TRANSPARENT=true&LAYERS=myWindLayer&STYLES=default&WIDTH=256&HEIGHT=256&FORMAT=image/png&BBOX={bbox-epsg-3857}&CRS=EPSG:3857`


I also add  a  example  in README of maplibre-wind

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WMS-compatible tile sources: URL templates can use a Web Mercator BBOX variable.
  * Tile source URL variables now accept hyphenated names and merge built-in defaults with user-provided URL data.

* **Documentation**
  * Added README example demonstrating a WMS-backed tile layer and parameter configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->